### PR TITLE
Implemented readlink and symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CFLAGS = -DHAVE_CONFIG_H \
 JSFLAGS = \
 	-s ASYNCIFY \
 	-s ASYNCIFY_IMPORTS="['blk_read', 'blk_write', 'discard', 'flush']" \
-	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
+	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_readlink', '_node_ext2fs_symlink', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall']" \
 	--pre-js $(prejs)
 

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -266,8 +266,35 @@ module.exports = function(constants, fsPointer) {
 		);
 	};
 
-	exports.readlink = function() {
-		throw new Error('Unimplemented');
+	async function readlink(path, encoding) {
+		if (encoding === undefined) {
+			encoding = 'utf8';
+		}
+
+		const array = [];
+		await Module.withObjectId(array, async (arrayId) => {
+			await withPathAsHeapBuffer(path, async (heapBufferPointer) => {
+				await ccallThrowAsync('node_ext2fs_readlink', 'number', ['number', 'number', 'number'], [fsPointer, heapBufferPointer, arrayId]);
+			});
+		});
+
+		const target = array[0];
+
+		if (encoding === 'buffer') {
+			return target;
+		} else {
+			return target.toString(encoding);
+		}
+	}
+
+	exports.readlink = function(path, encoding, req) {
+		promiseToCallback(
+			readlink(
+				path,
+				encoding
+			),
+			getCallback(req),
+		);
 	};
 
 	exports.rename = function() {
@@ -311,8 +338,28 @@ module.exports = function(constants, fsPointer) {
 		throw new Error('Unimplemented');
 	};
 
-	exports.symlink = function() {
-		throw new Error('Unimplemented');
+	async function symlink(path, linkpath, type) {
+		if (type) {
+			throw new Error('Unimplemented');
+		}
+
+		await withPathAsHeapBuffer(path, async (pathAsHeapBuffer) => {
+			await withPathAsHeapBuffer(linkpath, async (linkpathAsHeapBuffer) => {
+				await ccallThrowAsync(
+					'node_ext2fs_symlink',
+					'number',
+					['number', 'number', 'number'],
+					[fsPointer, pathAsHeapBuffer, linkpathAsHeapBuffer],
+				);
+			});
+		});
+	}
+
+	exports.symlink = function(path, linkpath, type, req) {
+		promiseToCallback(
+			symlink(path, linkpath, type),
+			getCallback(req),
+		);
 	};
 
 	exports.unlink = function(path, req) {

--- a/src/ext2fs.h
+++ b/src/ext2fs.h
@@ -9,6 +9,7 @@ extern "C" {
 typedef long     errcode_t;
 typedef uint32_t dgrp_t;
 typedef uint32_t blk_t;
+typedef uint64_t blk64_t;
 typedef uint32_t ext2_ino_t;
 typedef uint32_t ext2_off_t;
 
@@ -86,6 +87,8 @@ typedef __u64 ext2_off64_t;
 #define LINUX_S_IROTH 00004
 #define LINUX_S_IWOTH 00002
 #define LINUX_S_IXOTH 00001
+
+#define LINUX_S_ISLNK(m)	(((m) & LINUX_S_IFMT) == LINUX_S_IFLNK)
 
 typedef void* io_stats;
 typedef void* ext2fs_inode_bitmap;
@@ -248,6 +251,43 @@ errcode_t ext2fs_link(
 	const char *name,
 	ext2_ino_t ino,
 	int flags
+);
+
+errcode_t ext2fs_symlink(
+	ext2_filsys fs,
+	ext2_ino_t parent,
+	ext2_ino_t ino,
+	const char *name,
+	const char *target
+);
+
+int ext2fs_is_fast_symlink(struct ext2_inode *inode);
+extern errcode_t ext2fs_get_memzero(unsigned long size, void *ptr);
+
+extern errcode_t ext2fs_inline_data_get(
+	ext2_filsys fs,
+	ext2_ino_t ino,
+	struct ext2_inode *inode,
+	void *buf,
+	size_t *size
+);
+
+extern errcode_t ext2fs_bmap2(
+	ext2_filsys fs,
+	ext2_ino_t ino,
+	struct ext2_inode *inode,
+	char *block_buf,
+	int bmap_flags,
+	blk64_t block,
+	int *ret_flags,
+	blk64_t *phys_blk
+);
+
+errcode_t io_channel_read_blk64(
+	io_channel channel,
+	unsigned long long block,
+	int count,
+	void *data
 );
 
 extern errcode_t ext2fs_expand_dir(ext2_filsys fs, ext2_ino_t dir);

--- a/test/index.js
+++ b/test/index.js
@@ -779,4 +779,42 @@ describe('ext2fs', () => {
 			}
 		});
 	});
+
+	describe('symlink', () => {
+		const target = '/usr/bin/echo';
+		const linkpath = '/testlink';
+
+		testOnAllDisksMount(async (fs) => {
+			await fs.symlinkAsync(target, linkpath);
+			const [targetActual] = await fs.readlinkAsync(linkpath);
+
+			assert.strictEqual(targetActual, target);
+		});
+	});
+
+	describe('readlink non-existing', () => {
+		const filename = '/testlink';
+
+		testOnAllDisksMount(async (fs) => {
+			await assert.rejects(async() => {
+				await fs.readlinkAsync(filename);
+			}, (err) => {
+				return err.code === 'ENOENT';
+			});
+		});
+	});
+
+	describe('readlink non-link', () => {
+		const filename = '/testlink';
+
+		testOnAllDisksMount(async (fs) => {
+			await fs.writeFileAsync(filename, 'Hello, World!');
+
+			await assert.rejects(async() => {
+				await fs.readlinkAsync(filename);
+			}, (err) => {
+				return err.code === 'EINVAL';
+			});
+		});
+	});
 });


### PR DESCRIPTION
In order to address Issue #75 I implemented the readlink and symlink calls.

The logic for `node_ext2fs_readlink()`  is more or less a copy of [the e2fsprogs implementation in lib/ext2fs/namei.c](https://github.com/tytso/e2fsprogs/blob/67f2b54667e65cf5a478fcea8b85722be9ee6e8d/lib/ext2fs/namei.c#L44). If there is an easier way to do it, I didn't find it.

The `type` parameter of symlink is not implemented (and also not needed IMHO).

I added some basic tests, but it's not really tested in production.