### PR TITLE
Improve symlink support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CFLAGS = -DHAVE_CONFIG_H \
 JSFLAGS = \
 	-s ASYNCIFY \
 	-s ASYNCIFY_IMPORTS="['blk_read', 'blk_write', 'discard', 'flush']" \
-	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
+	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_symlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall']" \
 	--pre-js $(prejs)
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CFLAGS = -DHAVE_CONFIG_H \
 JSFLAGS = \
 	-s ASYNCIFY \
 	-s ASYNCIFY_IMPORTS="['blk_read', 'blk_write', 'discard', 'flush']" \
-	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_symlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
+	-s EXPORTED_FUNCTIONS="['_malloc_from_js', '_free_from_js', '_node_ext2fs_mount', '_node_ext2fs_trim', '_node_ext2fs_readdir', '_node_ext2fs_open', '_node_ext2fs_read', '_node_ext2fs_write', '_node_ext2fs_unlink', '_node_ext2fs_chmod', '_node_ext2fs_chown', '_node_ext2fs_mkdir', '_node_ext2fs_readlink', '_node_ext2fs_symlink', '_node_ext2fs_close', '_node_ext2fs_umount', '_node_ext2fs_stat_i_mode', '_node_ext2fs_stat_i_links_count', '_node_ext2fs_stat_i_uid', '_node_ext2fs_stat_i_gid', '_node_ext2fs_stat_blocksize', '_node_ext2fs_stat_ino', '_node_ext2fs_stat_i_size', '_node_ext2fs_stat_i_blocks', '_node_ext2fs_stat_i_atime', '_node_ext2fs_stat_i_mtime', '_node_ext2fs_stat_i_ctime']" \
 	-s EXPORTED_RUNTIME_METHODS="['ccall']" \
 	--pre-js $(prejs)
 

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -285,8 +285,35 @@ module.exports = function(constants, fsPointer) {
 		);
 	};
 
-	exports.readlink = function() {
-		throw new Error('Unimplemented');
+	async function readlink(path, encoding) {
+		if (encoding === undefined) {
+			encoding = 'utf8';
+		}
+
+		const array = [];
+		await Module.withObjectId(array, async (arrayId) => {
+			await withPathAsHeapBuffer(path, async (heapBufferPointer) => {
+				await ccallThrowAsync('node_ext2fs_readlink', 'number', ['number', 'number', 'number'], [fsPointer, heapBufferPointer, arrayId]);
+			});
+		});
+
+		const target = array[0];
+
+		if (encoding === 'buffer') {
+			return target;
+		} else {
+			return target.toString(encoding);
+		}
+	}
+
+	exports.readlink = function(path, encoding, req) {
+		promiseToCallback(
+			readlink(
+				path,
+				encoding
+			),
+			getCallback(req),
+		);
 	};
 
 	exports.rename = function() {
@@ -330,15 +357,18 @@ module.exports = function(constants, fsPointer) {
 		throw new Error('Unimplemented');
 	};
 
-	async function symlink(target, path) {
-		// type is unsupported by ext2fs, but maintaining it here for compatibility
-		return await withPathAsHeapBuffer(target, async (hbp_target) => {
-			await withPathAsHeapBuffer(path, async (hbp_path) => {
+	async function symlink(target, path, type) {
+		if (type) {
+			throw new Error('Unimplemented');
+		}
+
+		await withPathAsHeapBuffer(path, async (pathAsHeapBuffer) => {
+			await withPathAsHeapBuffer(target, async (targetAsHeapBuffer) => {
 				await ccallThrowAsync(
 					'node_ext2fs_symlink',
 					'number',
 					['number', 'number', 'number'],
-					[fsPointer, hbp_path, hbp_target],
+					[fsPointer, pathAsHeapBuffer, targetAsHeapBuffer],
 				);
 			});
 		});

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -19,6 +19,14 @@ function getCallback(req) {
 }
 
 module.exports = function(constants, fsPointer) {
+	const {
+		X_OK = 0,
+		O_RDONLY,
+		O_NOFOLLOW,
+		S_IXUSR,
+		S_IXGRP,
+		S_IXOTH,
+	} = constants;
 	const exports = {};
 
 	const openFiles = new Map();
@@ -34,12 +42,12 @@ module.exports = function(constants, fsPointer) {
 
 	async function access(path, mode) {
 		const X = (
-			constants.S_IXUSR |
-			constants.S_IXGRP |
-			constants.S_IXOTH
+			S_IXUSR |
+      S_IXGRP |
+      S_IXOTH
 		);
 		const stats = await stat(path);
-		if (((mode & constants.X_OK) !== 0) && ((stats.mode & X) === 0)) {
+		if (((mode & X_OK) !== 0) && ((stats.mode & X) === 0)) {
 			throw new ErrnoException(CODE_TO_ERRNO['EACCES'], 'access', [path, mode]);
 		}
 	}
@@ -172,8 +180,18 @@ module.exports = function(constants, fsPointer) {
 		throw new Error('Unimplemented');
 	};
 
-	exports.lstat = function() {
-		throw new Error('Unimplemented');
+	async function lstat(path) {
+		const fd = await open(path, O_RDONLY | O_NOFOLLOW);
+		const stats = await fstat(fd);
+		await close(fd);
+		return stats;
+	}
+
+	exports.lstat = function(path, req) {
+		promiseToCallback(
+			lstat(path),
+			getCallback(req),
+		);
 	};
 
 	async function mkdir(path, mode) {

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -167,6 +167,7 @@ module.exports = function(constants, fsPointer) {
 		throw new Error('Unimplemented');
 	};
 
+
 	exports.link = function() {
 		throw new Error('Unimplemented');
 	};
@@ -311,9 +312,27 @@ module.exports = function(constants, fsPointer) {
 		throw new Error('Unimplemented');
 	};
 
-	exports.symlink = function() {
-		throw new Error('Unimplemented');
+	async function symlink(target, path) {
+		// type is unsupported by ext2fs, but maintaining it here for compatibility
+		return await withPathAsHeapBuffer(target, async (hbp_target) => {
+			await withPathAsHeapBuffer(path, async (hbp_path) => {
+				await ccallThrowAsync(
+					'node_ext2fs_symlink',
+					'number',
+					['number', 'number', 'number'],
+					[fsPointer, hbp_path, hbp_target],
+				);
+			});
+		});
+	}
+
+	exports.symlink = function(target, path, req) {
+		promiseToCallback(
+			symlink(target, path),
+			getCallback(req),
+		);
 	};
+
 
 	exports.unlink = function(path, req) {
 		promiseToCallback(

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -738,18 +738,18 @@ fs.readlink = function(path, options, callback) {
   binding.readlink(path, options.encoding, req);
 };
 
-function preprocessSymlinkDestination(path, type, linkPath) {
+function preprocessSymlinkDestination(target, type, path) {
   if (!isWindows) {
     // No preprocessing is needed on Unix.
-    return path;
+    return target;
   } else if (type === 'junction') {
-    // Junctions paths need to be absolute and \\?\-prefixed.
+    // Junctions targets need to be absolute and \\?\-prefixed.
     // A relative target is relative to the link's parent directory.
-    path = pathModule.resolve(linkPath, '..', path);
-    return path;
+    target = targetModule.resolve(path, '..', target);
+    return target;
   } else {
     // Windows symlinks don't tolerate forward slashes.
-    return ('' + path).replace(/\//g, '\\');
+    return ('' + target).replace(/\//g, '\\');
   }
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -407,7 +407,7 @@ function readFileAfterStat(err, st) {
   if (err)
     return context.close(err);
 
-  
+
   var size = context.size = st.isFile() ? st.size : 0;
 
   if (size === 0) {
@@ -765,7 +765,7 @@ fs.symlink = function(target, path, type_, callback_) {
 
   binding.symlink(preprocessSymlinkDestination(target, type, path),
                   path,
-                  type,
+                  // type, <- not supported by ext4
                   req);
 };
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "make -j $(nproc)",
     "prepare": "npm run build",
-    "pretest": "eslint lib test src/pre.js",
+    "pretest": "eslint --fix lib test src/pre.js",
     "test": "mocha"
   },
   "devDependencies": {

--- a/src/ext2fs.h
+++ b/src/ext2fs.h
@@ -9,6 +9,7 @@ extern "C" {
 typedef long     errcode_t;
 typedef uint32_t dgrp_t;
 typedef uint32_t blk_t;
+typedef uint64_t blk64_t;
 typedef uint32_t ext2_ino_t;
 typedef uint32_t ext2_off_t;
 
@@ -86,6 +87,8 @@ typedef __u64 ext2_off64_t;
 #define LINUX_S_IROTH 00004
 #define LINUX_S_IWOTH 00002
 #define LINUX_S_IXOTH 00001
+
+#define LINUX_S_ISLNK(m)	(((m) & LINUX_S_IFMT) == LINUX_S_IFLNK)
 
 typedef void* io_stats;
 typedef void* ext2fs_inode_bitmap;
@@ -264,6 +267,43 @@ errcode_t ext2fs_link(
 	const char *name,
 	ext2_ino_t ino,
 	int flags
+);
+
+errcode_t ext2fs_symlink(
+	ext2_filsys fs,
+	ext2_ino_t parent,
+	ext2_ino_t ino,
+	const char *name,
+	const char *target
+);
+
+int ext2fs_is_fast_symlink(struct ext2_inode *inode);
+extern errcode_t ext2fs_get_memzero(unsigned long size, void *ptr);
+
+extern errcode_t ext2fs_inline_data_get(
+	ext2_filsys fs,
+	ext2_ino_t ino,
+	struct ext2_inode *inode,
+	void *buf,
+	size_t *size
+);
+
+extern errcode_t ext2fs_bmap2(
+	ext2_filsys fs,
+	ext2_ino_t ino,
+	struct ext2_inode *inode,
+	char *block_buf,
+	int bmap_flags,
+	blk64_t block,
+	int *ret_flags,
+	blk64_t *phys_blk
+);
+
+errcode_t io_channel_read_blk64(
+	io_channel channel,
+	unsigned long long block,
+	int count,
+	void *data
 );
 
 extern errcode_t ext2fs_expand_dir(ext2_filsys fs, ext2_ino_t dir);

--- a/src/ext2fs.h
+++ b/src/ext2fs.h
@@ -103,6 +103,14 @@ extern errcode_t ext2fs_namei(
 	ext2_ino_t *inode
 );
 
+errcode_t ext2fs_namei_follow(
+	ext2_filsys fs,
+	ext2_ino_t root,
+	ext2_ino_t cwd,
+	const char *name,
+	ext2_ino_t *inode
+);
+
 #define EXT2_ET_NO_MEMORY (2133571398L)
 
 extern errcode_t ext2fs_get_mem(unsigned long size, void *ptr);
@@ -240,6 +248,14 @@ extern errcode_t ext2fs_new_inode(
 	int mode,
 	ext2fs_inode_bitmap map,
 	ext2_ino_t *ret
+);
+
+errcode_t ext2fs_symlink(
+	ext2_filsys fs,
+	ext2_ino_t parent,
+	ext2_ino_t ino,
+	const char *name,
+	const char *target
 );
 
 errcode_t ext2fs_link(

--- a/src/glue.c
+++ b/src/glue.c
@@ -454,18 +454,28 @@ errcode_t node_ext2fs_symlink(
 	if (parent_ino == 0) {
 		return -ENOTDIR;
 	}
+
+	ext2_ino_t ino = string_to_inode(fs, name, 0);
+	if (ino) {
+		return -EEXIST;
+	}
+
 	char *filename = get_filename(name);
+	if (filename == NULL) {
+		// This should never happen.
+		return -EISDIR;
+	}
 
 	retval = ext2fs_symlink(fs, parent_ino, 0, filename, target);
 	if (retval == EXT2_ET_DIR_NO_SPACE) {
 		retval = ext2fs_expand_dir(fs, parent_ino);
 		if (retval) {
-			return retval;
+			return -retval;
 		}
 		retval = ext2fs_symlink(fs, parent_ino, 0, filename, target);
 	}
 
-	return retval;
+	return -retval;
 }
 
 errcode_t node_ext2fs_unlink(
@@ -529,6 +539,76 @@ errcode_t node_ext2fs_chown(
 	increment_version(&(file->inode));
 	ret = ext2fs_write_inode(file->fs, file->ino, &(file->inode));
 	return -ret;
+}
+
+errcode_t node_ext2fs_readlink(
+	ext2_filsys fs,
+	const char* path,
+	int array_id
+) {
+	errcode_t ret = 0;
+	struct ext2_inode ei;
+	char* buffer = 0;
+	char* pathname;
+	blk64_t blk;
+
+	ext2_ino_t ino = string_to_inode(fs, path, 0);
+	if (!ino) {
+		return -ENOENT;
+	}
+
+	ret = ext2fs_read_inode(fs, ino, &ei);
+	if (ret) {
+		return -ret;
+	}
+
+	if (!LINUX_S_ISLNK(ei.i_mode)) {
+		return -EINVAL;
+	}
+
+	if (ext2fs_is_fast_symlink(&ei)) {
+		pathname = (char *)&(ei.i_block[0]);
+	}
+	else if (ei.i_flags & EXT4_INLINE_DATA_FL) {
+		ret = ext2fs_get_memzero(ei.i_size, &buffer);
+		if (ret) {
+			return -ret;
+		}
+
+		ret = ext2fs_inline_data_get(fs, ino, &ei, buffer, NULL);
+		if (ret) {
+			ext2fs_free_mem(&buffer);
+			return -ret;
+		}
+
+		pathname = buffer;
+	} else {
+		ret = ext2fs_bmap2(fs, ino, &ei, NULL, 0, 0, NULL, &blk);
+		if (ret) {
+			return -ret;
+		}
+
+		ret = ext2fs_get_mem(fs->blocksize, &buffer);
+		if (ret) {
+			return -ret;
+		}
+
+		ret = io_channel_read_blk64(fs->io, blk, 1, buffer);
+		if (ret) {
+			ext2fs_free_mem(&buffer);
+			return -ret;
+		}
+
+		pathname = buffer;
+	}
+
+	array_push_buffer(array_id, pathname, strlen(pathname));
+
+	if (buffer) {
+		ext2fs_free_mem(&buffer);
+	}
+
+	return ret;
 }
 
 errcode_t node_ext2fs_close(ext2_file_t file) {

--- a/test/index.js
+++ b/test/index.js
@@ -502,6 +502,25 @@ describe('ext2fs', () => {
 		});
 	});
 
+	describe('symlink', () => {
+		const target = '/config.txt';
+		const content = 'content\n';
+		const content2 = 'content2\n';
+		const encoding = 'utf8';
+		const symlink = '/symconfig.txt';
+		testOnAllDisksMount(async (fs) => {
+			await fs.writeFileAsync(target, content, encoding);
+			await fs.symlinkAsync(target, symlink);
+			const [data] = await fs.readFileAsync(symlink, encoding);
+			assert.strictEqual(data, content);
+			const [fd] = await fs.openAsync(symlink, 'w+');
+			await fs.writeAsync(fd, content2);
+			await fs.closeAsync(fd);
+			const [data2] = await fs.readFileAsync(symlink, encoding);
+			assert.strictEqual(data2, content2);
+		});
+	});
+
 	describe('write in a readonly file', () => {
 		testOnAllDisksMount(async (fs) => {
 			const [fd] = await fs.openAsync('/1', 'r');

--- a/test/index.js
+++ b/test/index.js
@@ -502,7 +502,9 @@ describe('ext2fs', () => {
 		});
 	});
 
-	describe('symlink', () => {
+	describe('symlink read/write', () => {
+		// symlink content should be the same as the
+		// original file content after reading and writing
 		const target = '/config.txt';
 		const content = 'content\n';
 		const content2 = 'content2\n';
@@ -518,6 +520,8 @@ describe('ext2fs', () => {
 			await fs.closeAsync(fd);
 			const [data2] = await fs.readFileAsync(symlink, encoding);
 			assert.strictEqual(data2, content2);
+			const [stat] = await fs.lstatAsync(symlink);
+			assert.strictEqual(stat.isSymbolicLink(), true);
 		});
 	});
 


### PR DESCRIPTION
This PR enables

* `fs.lstat`
* `fs.readlink`

to work properly, along with the `O_NOFOLLOW` flag in `fs.open`