### PR TITLE
Fixed memory leak in js_zeroout_entry

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -728,6 +728,7 @@ static errcode_t js_zeroout_entry(io_channel channel, unsigned long long block, 
 	char *data = malloc(size);
 	memset(data, 0, size);
 	errcode_t ret = blk_write(disk_id, channel->block_size, block, count, data);
+	free(data);
 	if (ret) return ret;
 	return discard(disk_id, channel->block_size, block, count);
 }


### PR DESCRIPTION
Taking over this PR for @skadisch to comply with our guidelines (version bot increase version) See https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md#creating-commits-in-line-with-semantic-versioning