### PR TITLE
Fix fs.stat for large file sizes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -15,4 +15,3 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit
-    with: {}

--- a/src/glue.c
+++ b/src/glue.c
@@ -283,8 +283,8 @@ errcode_t update_xtime(ext2_file_t file, bool a, bool c, bool m) {
 	return err;
 }
 
-unsigned long getUInt64Number(unsigned long long hi, unsigned long long lo) {
-	return lo | (hi << 32);
+double getUInt64Number(unsigned long long hi, unsigned long long lo) {
+	return (double) ((hi << 32) | lo);
 }
 // ------------------------
 
@@ -1377,7 +1377,7 @@ int node_ext2fs_stat_blocksize(ext2_file_t file) {
 	return file->fs->blocksize;
 }
 
-unsigned long node_ext2fs_stat_i_size(ext2_file_t file) {
+double node_ext2fs_stat_i_size(ext2_file_t file) {
 	return getUInt64Number(file->inode.i_size_high, file->inode.i_size);
 }
 


### PR DESCRIPTION
The the size of an image was > ~4GB (max value that could be stored in a 32-bit integer the stat function threw an error - there was a type mismatch between node and the c function that combined the upper and lower 32 bits of the image size that is stored in the inode.

Change-type: patch

Attempts to fix: https://github.com/balena-os/jetson-flash/issues/194